### PR TITLE
Add initial database integration

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-MONGO_URI=mongodb+srv://Paul:Looking1@cluster0.5nmsv.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+MONGO_URI=mongodb+srv://jbalcombe:80ie3zeQHTY7D52n@quant-db-3011.ejicw.mongodb.net/?retryWrites=true&w=majority&appName=Quant-DB-3011

--- a/insert_data.py
+++ b/insert_data.py
@@ -6,11 +6,11 @@ from dotenv import load_dotenv
 # Load MongoDB connection URI
 
 load_dotenv()  # Load .env variables
-mongo_uri = os.getenv("MONGO_URI")  # This will have to be the URI from the actual DB
+mongo_uri = os.getenv("MONGO_URI")
 
 try:
     client = MongoClient(mongo_uri)  # 5 sec timeout
-    db = client["quant_data"]  # Replace with your actual DB name
+    db = client["quant_data"]
     collection = db["news_articles"]
 
     # Check connection

--- a/insert_data.py
+++ b/insert_data.py
@@ -1,4 +1,5 @@
 import os
+import datetime
 from pymongo import MongoClient
 from dotenv import load_dotenv
 
@@ -9,8 +10,8 @@ mongo_uri = os.getenv("MONGO_URI")  # This will have to be the URI from the actu
 
 try:
     client = MongoClient(mongo_uri)  # 5 sec timeout
-    db = client["qubit_database"]  # Replace with your actual DB name
-    collection = db["stocks"]
+    db = client["quant_data"]  # Replace with your actual DB name
+    collection = db["news_articles"]
 
     # Check connection
     print(client.server_info())  # Should print server details
@@ -57,6 +58,18 @@ sample_data = [
     }
 ]
 
+# Need to run the following datetime command in order for publishedAt to actually
+# be inserted in datetime format instead of just a string
+sample_data_2 = [
+    {
+        "tickers": "AAPL",
+        "title": "Apple Stock Surges After Strong Earnings Report",
+        "content": "Apple reported better-than-expected quarterly earnings, driven by strong iPhone sales and growth in its services segment.",
+        "publishedAt": datetime.datetime.fromisoformat("2025-03-10T14:30:00Z"),
+        "source": "Bloomberg"
+    }
+]
+
 # Insert data into MongoDB
-insert_result = collection.insert_many(sample_data)
+insert_result = collection.insert_many(sample_data_2)
 print(f"Inserted {len(insert_result.inserted_ids)} documents.")


### PR DESCRIPTION
This pull request adds initial integration of the data collection API with our database. The correct URI (including password) has been added, and data from `insert_data.py` can now be added to the collection I created in the database.

I noticed that the dates were being inserted into the DB as strings instead of the actual `datetime` type, so I modified some of the sample data to convert the strings to `datetime`, which seems to work.

Note that the field names in the sample data do not match the field names I was planning on using in the database, but the data can still be inserted anyway because there is no schema. We can decide on a consistent naming scheme later (I recommend using snake case since most of our code is already in snake case).

The database was previously configured to only accept queries from my IP address, but I have now changed it to accept queries from any IP. Please let me know if it works.