### PR TITLE
small change to imports in server tests

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,4 @@
-from server import app
+# from server import app
 import unittest
 from datetime import datetime
 import sys


### PR DESCRIPTION
Basically there was a small issue where there were two lines of "import app from server". But server was in another directory so it actually had to add the ../src directory to the python path. The first import was done without doing this, the second import was done after doing this. Therefore, i just removed the first line