### PR TITLE
Fix a bug where duplicate time intervals are created for the same company

### DIFF
--- a/src/functions.py
+++ b/src/functions.py
@@ -197,9 +197,11 @@ def write_to_database(data, source_name):
 
 
 def add_new_index(name, from_date, to_date):
+    name_lower = name.strip().lower()
+
     interval_collection = db["company_index"]
     result = interval_collection.find_one(
-        {"name": name}, {"_id": 0, "intervals": 1})
+        {"name": name_lower}, {"_id": 0, "intervals": 1})
 
     query = {}
     update = {}  # NEW
@@ -213,13 +215,13 @@ def add_new_index(name, from_date, to_date):
         # interval_collection.update_one(query)
 
         # 3 LINES BELOW ARE NEW
-        query["name"] = name
+        query["name"] = name_lower
         update["$set"] = {"time_intervals": intervals}
         interval_collection.update_one(query, update)
 
     else:
         query = {
-            "name": name,
+            "name": name_lower,
             "time_intervals": [[from_date, to_date]],
             "hits": 0,
             "misses": 0

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -31,8 +31,8 @@ class testApiFetchCalls(unittest.TestCase):
         self.assertIn("events", result)
 
     def test_get_news_data_n_set_dates(self):
-        from_date = datetime.fromisoformat("2025-03-04T14:30:00Z")
-        to_date = datetime.fromisoformat("2025-03-10T14:30:00Z")
+        from_date = datetime.fromisoformat("2025-04-04T14:30:00Z")
+        to_date = datetime.fromisoformat("2025-04-10T14:30:00Z")
         result = get_news_data_n("facebook", from_date, to_date)
         self.assertIsInstance(result, dict)
         self.assertIn("events", result)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -54,14 +54,14 @@ class testQubitApis(unittest.TestCase):
 
     def test_newsapi_with_dates(self):
         # testing the correct flow with start and end dates
-        response = self.app.get("/newsapi?name=Facebook&from_date=2025-03-04&to_date=2025-03-10")
+        response = self.app.get("/newsapi?name=Facebook&from_date=2025-04-04&to_date=2025-04-10")
         self.assertEqual(response.status_code, 200)
         self.assertIn("events", response.get_json())
 
     def test_newsapi_missing_name(self):
         # no name paramater given --> return error code 400 + errr msg
         response = self.app.get(
-            "/newsapi?from_date=2025-03-04&to_date=2025-03-10")
+            "/newsapi?from_date=2025-04-04&to_date=2025-04-10")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json(), {
                          "error": "Invalid 'name' given"})
@@ -69,14 +69,14 @@ class testQubitApis(unittest.TestCase):
     def test_newsapi_invalid_name(self):
         # name has AND operation --> invalid name --> return code 400 + err msg
         response = self.app.get(
-            "/newsapi?name=Facebook+AND+Apple&from_date=2025-03-04&to_date=2025-03-10")
+            "/newsapi?name=Facebook+AND+Apple&from_date=2025-04-04&to_date=2025-04-10")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json(), {
                          "error": "Invalid 'name' given"})
 
     def test_newsapi_missing_dates(self):
         # only one date provided -> 400 + err msg
-        response = self.app.get("/newsapi?name=Apple&from_date=2025-03-04")
+        response = self.app.get("/newsapi?name=Apple&from_date=2025-04-04")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json(), {
                          "error": "Please provide both to and from dates or none"})
@@ -84,7 +84,7 @@ class testQubitApis(unittest.TestCase):
     def test_newsapi_invalid_date_format(self):
         # incorrect date format -> 400 + err msg
         response = self.app.get(
-            "/newsapi?name=Facebook&from_date=03-04-2025&to_date=2025/03/10")
+            "/newsapi?name=Facebook&from_date=04-04-2025&to_date=2025/04/10")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json(), {
                          "error": "Date values must be of ISO 8601 format (e.g. 2025-03-04 or 2025-03-04T07:11:59)"})


### PR DESCRIPTION
This pull request fixes a bug where multiple time intervals are sometimes created in the database for the same company, because using a different case in the company name:

![ksnip_20250411-143535](https://github.com/user-attachments/assets/0727bf57-43eb-46ce-9e8d-b057a40b1e9e)

To fix this issue, I made it so all company names are converted to lower case before use with the `company_index` collection.

**Note that when this change is deployed, all news-related collections in the database need to be reset to avoid further problems**
