### PR TITLE
Add routes to convert company names to tickers (and vice versa)

### DIFF
--- a/src/functions.py
+++ b/src/functions.py
@@ -240,7 +240,8 @@ def company_to_ticker(name: str):
         'q': name
     }
 
-    response = requests.get(base_url, params=params, headers={'User-Agent': user_agent})
+    response = requests.get(base_url, params=params, headers={
+                            'User-Agent': user_agent})
 
     if response.status_code == 200:
         data = response.json()
@@ -259,7 +260,8 @@ def ticker_to_company(ticker: str):
         'q': ticker
     }
 
-    response = requests.get(base_url, params=params, headers={'User-Agent': user_agent})
+    response = requests.get(base_url, params=params, headers={
+                            'User-Agent': user_agent})
 
     if response.status_code == 200:
         data = response.json()

--- a/src/functions.py
+++ b/src/functions.py
@@ -230,7 +230,45 @@ def add_new_index(name, from_date, to_date):
         interval_collection.insert_one(query)
 
 
-# Make a job scheduler fucntion,
+def company_to_ticker(name: str):
+    base_url = "https://query2.finance.yahoo.com/v1/finance/search"
+
+    params = {
+        'q': name
+    }
+
+    response = requests.get(base_url, params=params)
+
+    if response.status_code == 200:
+        data = response.json()
+        ticker = data['quotes'][0]['symbol']
+        return ticker
+    else:
+        return f"Error: {response.status_code}, {response.text}"
+
+
+def ticker_to_company(ticker: str, full_name: bool):
+    base_url = "https://query2.finance.yahoo.com/v1/finance/search"
+
+    params = {
+        'q': ticker
+    }
+
+    response = requests.get(base_url, params=params)
+
+    if response.status_code == 200:
+        data = response.json()
+        name = data['quotes'][0]['longname']
+
+        if not full_name:
+            name = name.lower().split()[0]
+
+        return name
+    else:
+        return f"Error: {response.status_code}, {response.text}"
+
+
+# Make a job scheduler function,
 # a job that is to be executed on a seperate thread once a day.
 # The job is to make N number of consecutive requests with every K minutes.
 # - not certainly required, could change based on learning more about AWS lambda

--- a/src/functions.py
+++ b/src/functions.py
@@ -6,7 +6,10 @@ from datetime import datetime, timedelta
 from pymongo import MongoClient
 from dotenv import load_dotenv
 import copy
+import re
 from time_interval import add_interval
+
+user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36'
 
 
 # Load environment variables
@@ -237,33 +240,39 @@ def company_to_ticker(name: str):
         'q': name
     }
 
-    response = requests.get(base_url, params=params)
+    response = requests.get(base_url, params=params, headers={'User-Agent': user_agent})
 
     if response.status_code == 200:
         data = response.json()
         ticker = data['quotes'][0]['symbol']
-        return ticker
+        return {
+            "ticker": ticker
+        }
     else:
         return f"Error: {response.status_code}, {response.text}"
 
 
-def ticker_to_company(ticker: str, full_name: bool):
+def ticker_to_company(ticker: str):
     base_url = "https://query2.finance.yahoo.com/v1/finance/search"
 
     params = {
         'q': ticker
     }
 
-    response = requests.get(base_url, params=params)
+    response = requests.get(base_url, params=params, headers={'User-Agent': user_agent})
 
     if response.status_code == 200:
         data = response.json()
-        name = data['quotes'][0]['longname']
+        full_name = data['quotes'][0]['longname']
 
-        if not full_name:
-            name = name.lower().split()[0]
+        name_split = re.split(r"\W+", full_name.lower())
+        name = name_split[0]
 
-        return name
+        return {
+            "short_name": name,
+            "full_name": full_name
+        }
+
     else:
         return f"Error: {response.status_code}, {response.text}"
 

--- a/src/server.py
+++ b/src/server.py
@@ -73,7 +73,7 @@ def convert_company_to_ticker():
 
     if not name or not re.match(r'^[a-zA-Z\s]+$', name):
         return jsonify({"error": "Invalid 'name' given"}), 400
-    
+
     data = company_to_ticker(name=name)
     return jsonify(data)
 
@@ -85,14 +85,14 @@ def convert_ticker_to_company():
 
     if not ticker:
         return jsonify({"error": "Invalid 'name' given"}), 400
-    
+
     if not full_name:
         full_name = False
     elif full_name.strip().lower() == 'true':
         full_name = True
     else:
         full_name = False
-    
+
     data = ticker_to_company(ticker=ticker, full_name=full_name)
     return jsonify(data)
 

--- a/src/server.py
+++ b/src/server.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from flask import Flask, request, jsonify
 import re
 import os
-from functions import get_news_data_av, get_top_gainers_losers_av, get_news_data_n
+from functions import get_news_data_av, get_top_gainers_losers_av, get_news_data_n, company_to_ticker, ticker_to_company
 
 # Initialize Flask app
 SERVER_ADDRESS = os.getenv("FLASK_RUN_HOST", "127.0.0.1")
@@ -64,6 +64,36 @@ def newsapi():
         except ValueError:
             return jsonify({"error": "Date values must be of ISO 8601 format (e.g. 2025-03-04 or 2025-03-04T07:11:59)"}), 400
     data = get_news_data_n(name=name, from_date=from_date, to_date=to_date)
+    return jsonify(data)
+
+
+@app.route('/convert/company_to_ticker')
+def convert_company_to_ticker():
+    name = request.args.get('name')
+
+    if not name or not re.match(r'^[a-zA-Z\s]+$', name):
+        return jsonify({"error": "Invalid 'name' given"}), 400
+    
+    data = company_to_ticker(name=name)
+    return jsonify(data)
+
+
+@app.route('/convert/ticker_to_company')
+def convert_ticker_to_company():
+    ticker = request.args.get('ticker')
+    full_name = request.args.get('fullname')
+
+    if not ticker:
+        return jsonify({"error": "Invalid 'name' given"}), 400
+    
+    if not full_name:
+        full_name = False
+    elif full_name.strip().lower() == 'true':
+        full_name = True
+    else:
+        full_name = False
+    
+    data = ticker_to_company(ticker=ticker, full_name=full_name)
     return jsonify(data)
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -81,19 +81,11 @@ def convert_company_to_ticker():
 @app.route('/convert/ticker_to_company')
 def convert_ticker_to_company():
     ticker = request.args.get('ticker')
-    full_name = request.args.get('fullname')
 
     if not ticker:
-        return jsonify({"error": "Invalid 'name' given"}), 400
+        return jsonify({"error": "Invalid 'ticker' given"}), 400
 
-    if not full_name:
-        full_name = False
-    elif full_name.strip().lower() == 'true':
-        full_name = True
-    else:
-        full_name = False
-
-    data = ticker_to_company(ticker=ticker, full_name=full_name)
+    data = ticker_to_company(ticker=ticker)
     return jsonify(data)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -88,6 +88,57 @@ class testQubitApis(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json(), {
                          "error": "Date values must be of ISO 8601 format (e.g. 2025-03-04 or 2025-03-04T07:11:59)"})
+        
+    def test_company_to_ticker(self):
+        # testing the correct flow
+        test_cases = [
+            ["apple", "AAPL"],
+            ["google", "GOOG"],
+            ["microsoft", "MSFT"],
+            ["facebook", "META"],
+            ["adobe", "ADBE"],
+            ["amazon", "AMZN"],
+            ["tesla", "TSLA"],
+            ["atlassian", "TEAM"]
+        ]
+
+        for case in test_cases:
+            response = self.app.get(f"/convert/company_to_ticker?name={case[0]}")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.get_json(), {
+                            "ticker": case[1]})
+
+    def test_company_to_ticker_no_name(self):
+        # no name provided -> 400 + error msg
+        response = self.app.get("/convert/company_to_ticker")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {
+                         "error": "Invalid 'name' given"})
+
+    def test_ticker_to_company(self):
+        # testing the correct flow
+        test_cases = [
+            ["AAPL", "apple", "Apple Inc."],
+            ["MSFT", "microsoft", "Microsoft Corporation"],
+            ["ADBE", "adobe", "Adobe Inc."],
+            ["AMZN", "amazon", "Amazon.com, Inc."],
+            ["TSLA", "tesla", "Tesla, Inc."],
+            ["TEAM", "atlassian", "Atlassian Corporation"]
+        ]
+
+        for case in test_cases:
+            response = self.app.get(f"/convert/ticker_to_company?ticker={case[0]}")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.get_json(), {
+                            "short_name": case[1],
+                            "full_name": case[2]})
+
+    def test_ticker_to_company_no_ticker(self):
+        # no ticker provided -> 400 + error msg
+        response = self.app.get("/convert/ticker_to_company")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {
+                         "error": "Invalid 'ticker' given"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request adds two new routes to Collection, which can be used to convert company names to tickers (and vice versa). The endpoints have already been documented on our [Confluence page](https://unsw-seng-2025.atlassian.net/wiki/spaces/H17AALPHA/pages/51347527/Interface#Endpoint%3A-%2Fconvert%2Fcompany_to_ticker). These routes are required functionality if we want to integrate our API with teams whose APIs only accept tickers (eg. TradeTuah)

Yahoo Finance was used to do the conversions.

The route that converts company names to tickers should work almost every time. It works even for companies with a different official name from the name that consumers use, eg. Google, Facebook:
![ksnip_20250415-025104](https://github.com/user-attachments/assets/ed099f36-9ade-489b-a926-d88e782d77d5)

The route that converts tickers to company names works *most* of the time. It does not work for companies with a different official name from the name that consumers use. However, due to the use of Regex, it works for the majority of companies, even those with weird trading names like Amazon!
![ksnip_20250415-025105](https://github.com/user-attachments/assets/8b1c121f-53c0-4058-88cc-70d0184026f2)

The idea is to have a full name field with the company's full trading name, and a separate short name field with an (all lowercase) short version of the company name, which can be used with our API.

Currently, the routes do not write anything to the database. Eventually, they will do so, and we will also manually add database entries for companies that the ticker to company route doesn't work with (eg. Google, Facebook), which will be prioritised by Retrieval APIs.