### PR TITLE
fix pipeline cache issue

### DIFF
--- a/.github/workflows/data-collection-ci.yml
+++ b/.github/workflows/data-collection-ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.11"
         cache: 'pip'
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.11"
         cache: 'pip'
@@ -87,7 +87,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.11"
         cache: 'pip'
@@ -116,7 +116,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.11"
         cache: 'pip'


### PR DESCRIPTION
This pull request fixes an issue where the pipeline stopped working due to an older version of the Python cache being deprecated by GitHub